### PR TITLE
Looking for the kubeadm.env 

### DIFF
--- a/labs/kubernetes/destroy.sh
+++ b/labs/kubernetes/destroy.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-source $1
+source ${1:-kubeadm.env}
 
 cd terraform
 terraform destroy --auto-approve \


### PR DESCRIPTION
Error message when executing the script:

```
 [~/cluster2/datadog-experience/labs/kubernetes]$ ./destroy.sh  
./destroy.sh: line 5: $1: unbound variable
```

adding `source ${1:-kubeadm.env}` into the script