### PR TITLE
replace deprecated attributes and fix doc typo

### DIFF
--- a/labs/kubernetes/terraform/main.tf
+++ b/labs/kubernetes/terraform/main.tf
@@ -8,10 +8,10 @@ resource "tls_private_key" "ssh" {
   rsa_bits  = 4096
 }
 
-resource "local_file" "key_file" {
-  filename          = "${var.namespace}-private_key.pem"
-  file_permission   = "600"
-  sensitive_content = tls_private_key.ssh.private_key_pem
+resource "local_sensitive_file" "key_file" {
+  filename        = "${var.namespace}-private_key.pem"
+  file_permission = "600"
+  content         = tls_private_key.ssh.private_key_pem
 }
 
 resource "aws_key_pair" "main" {

--- a/labs/kubernetes/terraform/network.tf
+++ b/labs/kubernetes/terraform/network.tf
@@ -41,7 +41,7 @@ resource "aws_security_group" "main" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${chomp(data.http.myip.body)}/32"]
+    cidr_blocks = ["${chomp(data.http.myip.response_body)}/32"]
     self        = true
   }
 

--- a/learn-by-example/python-simple-app/README.md
+++ b/learn-by-example/python-simple-app/README.md
@@ -2,6 +2,6 @@
 
 ## Requirements
 
-- [NGINX Ingress](../labs/nginx)
+- [NGINX Ingress](../../labs/ingress-nginx)
 
 [Traces](https://app.datadoghq.com/apm/traces?query=service%3Aflask)


### PR DESCRIPTION
Warning by deprecated attributes bothers me, so I thought I could offer a quick and easy contribution.

I tested the new attributes with

```
Terraform v1.2.7
on darwin_arm64
```

This fix removes the deprecated warning messages for the Kubernetes lab config.