### PR TITLE
replace not supported AMI

### DIFF
--- a/labs/kubernetes/terraform/amis.tf
+++ b/labs/kubernetes/terraform/amis.tf
@@ -6,7 +6,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-hirsute-21.04-amd64-server*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server*"]
     # values = ["ubuntu/images/hvm-ssd/ubuntu-groovy-20.10-amd64-server*"]
     # values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*"]
     # values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*"]


### PR DESCRIPTION
Ubuntu Hirsute 21.04 reached EOL. This patch replaces it with Jammy 22.04 which is LTS.

Tested and working.